### PR TITLE
Sky gradients and more on the German version

### DIFF
--- a/FileSpecs/Amberdev.md
+++ b/FileSpecs/Amberdev.md
@@ -1,13 +1,26 @@
 # AMBERDEV data
 
-The `AMBERDEV.UDO` file contains an assortment of data (and possibly executable code?). Some known bits of interest below:
+The `AMBERDEV.UDO` file contains an assortment of data (and possibly executable code?). Some known bits of interest below.
+The start offsets are approximate and may vary across releases of the game; in particular, they vary between the English and German versions.
 
 | Start offset      | Description                             | Format                                                                     |
 |-------------------|-----------------------------------------|----------------------------------------------------------------------------|
 | `2170b`           | String Fragment Table                   | Described for [Compressed Text](FileSpecs/CompressedText.md)               |
 | `31a46`           | Background song names                   | 0-terminated string, terminated by another 0                               |
-| `33d70` (approx.) | Graphics                                | 16x16, details tbd                                                         |
-| `4cdc0`           | Songs, starting with "City Walk"        | [Background Music](Hippel-CoSo.md)                                         |
 | `31eda`           | [Combat Palette](Palettes.md): template | A palette used in combat with three "holes" (colours that are left black)  |
 | `31efa`           | [Combat Palette](Palettes.md): variants | List of colour triplets to fill the "holes" in the combat palette template |
+| `33d70` (approx.) | Graphics                                | 16x16, details tbd                                                         |
+| `473a4`           | [Sky gradients](LabData.md)             | Palette gradients for in-city sky day/night cycle                          |
+| `4ac0a`           | Spell names                             | individual u16 words of [Compressed Text](FileSpecs/CompressedText.md)     |
+| `4cdc0`           | Songs, starting with "City Walk"        | [Background Music](Hippel-CoSo.md)                                         |
 
+## Finding the offsets
+
+Below are some strategies for finding the correct offsets:
+
+- *String Fragment Table*: Start of the first occurrence of "`HUMAN`" or "`MENSCH`", minus one byte.
+- *Songs*: All occurrences of `COSO`
+- *Spell Names*: Immediately after the first occurrence of `00 00 00 00 01 62`
+- *Sky Gradients*: `0x3866` bytes before the spell name table
+- *Combat Palette template*: `0x5e5` bytes after the first occurrence of `CODETXT.AMB`
+- *Combat Palette variants*: `0x20` bytes after the Combat Palette template

--- a/FileSpecs/CompressedText.md
+++ b/FileSpecs/CompressedText.md
@@ -42,3 +42,15 @@ The following heuristic seems to produce decent results:
     - The next fragment is NOT the first fragment in the text
     - The previous fragment was NOT a newline
     - The next fragment starts with a letter, a number, a dash or a tilde symbol
+
+## Character Set
+
+Amberstar seems to use the Atari ST character set (even on the Amiga).  This is not relevant for the English version of the game, but it affects the German version,
+due to the placement of the `ß` character.  Concretely, the German release of Amberstar uses the following characters that are outside the ASCII character range:
+
+| Character | Codepoint |
+|-----------|-----------|
+| Ä         | `8e`      |
+| Ö         | `99`      |
+| Ü         | `9a`      |
+| ß         | `9e`      |

--- a/FileSpecs/LabData.md
+++ b/FileSpecs/LabData.md
@@ -22,8 +22,7 @@ These resources are stored in `LAB_DATA.AMB`.
 | 0xa + `num_labblock_refs`    | `palette` + 1         | u8   | Index into the list of [Palettes](Palettes.md), plus 1                               |
 
 - Ceiling and floor images, as well as all indexed LabBlock resources, use the specified palette.
-- For outdoor maps, the ceiling graphics show the sky; the image lacks the background colour gradient used for sunset and sunrise.  Most likely the ceiling images here use colour index 0xb for transparency and have
-  something special drawn behind them.
+- For 3D city views, the colour `11`/`0x0b` has a special meaning: transparency relative to the day/night sky gradient (see below)
 - When moving around in a Labyrinth, the floor and ceiling images are flipped after every step, except for outdoors images, where the ceiling image is flipped only when rotating.
 - When rotating, the ceiling image is also flipped (UNKNOWN: outdoors only or also in dungeons?)
 - When rotating, the floor images is not flipped outdoors (UNKNOWN: how about in dungeons?)
@@ -125,3 +124,22 @@ Furniture/decoration blocks are the only blocks that are drawn when on the same 
 |--------|---|---|---|
 | `@>` 3 | 2 | 1 | 0 |
 
+
+## Sky Gradient
+
+Cities have a background sky gradient.  This gradient is stored in [AMBERDEV.UDO](Amberdev.mc) and consists of three [Compact palettes](Palettes.md), in order:
+- Day gradient
+- Night gradient
+- Twilight gradient (dawn/dusk)
+Each gradient has 83 palette entries.  The gradients are stored without any intervening separator.
+Each palette entry specifies the sky colour for the corresponding scanline in the first-person view, going downwards.
+The game selects the gradients based on the time of day:
+
+| Time of day | Gradient |
+|-------------|----------|
+| 06:00-08:00 | Twilight |
+| 08:00-18:00 | Day      |
+| 06:00-08:00 | Twilight |
+| 20:00-06:00 | Night    |
+
+During twilight hours, there is some blending between the gradients; details tbd.

--- a/FileSpecs/Pixmaps.md
+++ b/FileSpecs/Pixmaps.md
@@ -76,23 +76,27 @@ The palette index of a pixel at index `x`, `y` is now given by the combination (
 - `line[y].bitplane[0].xword[x >> 4] & (0x8000 > (x & 0xf))` << 3
 
 
-## Interpreting Pixels: Palettes
+## Interpreting Pixels: Palettes and Transparency
 
 The table below lists the palettes for each pixmap.  For some pixmaps,
-index 0 is not drawn (transparent), also marked below.
+some pixels are transparent (not drawn):
 
-| File                       | Index 0                                    | Palette                                                                |
-|----------------------------|--------------------------------------------|------------------------------------------------------------------------|
-| `BACKGRND.AMB`             | drawn                                      | Defined in the referencing [LAB_DATA.AMB](LabData.md)                  |
-| `CHARDATA.AMB` (portraits) | ?                                          | ?                                                                      |
-| `COM_BACK.AMB`             | drawn                                      | [Combat Palettes](Palettes.md)                                         |
-| `F_T_ANIM.ICN`             | transparent                                | [Combat Palettes](Palettes.md) (see below)                             |
-| `ICON_DAT.AMB`             | drawn unless in the [overlay map](Maps.md) | Embedded in the [IconData](IconData.md)                                |
-| `LABBLOCK.AMB`             | transparent                                | Defined in the referencing [LAB_DATA.AMB](LabData.md)                  |
-| `MON_GFX.AMB`              | transparent                                | [Combat Palettes](Palettes.md) (any)                                   |
-| `PICS80.AMB`               | drawn                                      | Stored in same file in the next record, after the corresponding pixmap |
-| `PUZZLE.ICN`               | ?                                          | ?                                                                      |
-| `TACTIC.ICN`               | transparent                                | [Combat Palettes](Palettes.md) (any)                                   |
+| File                       | Transparent indices                       | Palette                                                                |
+|----------------------------|-------------------------------------------|------------------------------------------------------------------------|
+| `BACKGRND.AMB`             | 11 (see below)                            | Defined in the referencing [LAB_DATA.AMB](LabData.md)                  |
+| `CHARDATA.AMB` (portraits) | ?                                         | ?                                                                      |
+| `COM_BACK.AMB`             | none                                      | [Combat Palettes](Palettes.md)                                         |
+| `F_T_ANIM.ICN`             | 0                                         | [Combat Palettes](Palettes.md) (see below)                             |
+| `ICON_DAT.AMB`             | 0 for icons in the [overlay map](Maps.md) | Embedded in the [IconData](IconData.md)                                |
+| `LABBLOCK.AMB`             | 0, 11 (see below)                         | Defined in the referencing [LAB_DATA.AMB](LabData.md)                  |
+| `MON_GFX.AMB`              | 0                                         | [Combat Palettes](Palettes.md) (any)                                   |
+| `PICS80.AMB`               | none                                      | Stored in same file in the next record, after the corresponding pixmap |
+| `PUZZLE.ICN`               | ?                                         | ?                                                                      |
+| `TACTIC.ICN`               | 0                                         | [Combat Palettes](Palettes.md) (any)                                   |
+
+Colour `11`/`0x0b`: For first-person `LABBLOCK` and `BACKGRND` views drawn in 3D views of cities,
+the colour `11` is used as a colour key for transparency relative to the [sky gradient](LabData.md).
+This allows e.g. the Twinlake graveyard gate to show parts of the sky instead of the stone wall that would normally be behind the gate.
 
 Several pixmaps us the [Combat Palettes](Palettes.md):
 - `TACTIC.ICN`: only uses palette indices that are identical across combat palettes, so any combat palette is fine.


### PR DESCRIPTION
- Described relevant codepoints for German text encoding
- Added slightly more robust strategies for finding resources in `AMBERDEV.UDO`
- Added description of sky gradients (first-person day/night cycle)
