### PR TITLE
Kermits new notes (also contains long text about mechanics and stuff)

### DIFF
--- a/FileSpecs/CharData.md
+++ b/FileSpecs/CharData.md
@@ -4,97 +4,133 @@ Party members, NPCs and monsters.
 
 **Note:** This is **WIP** and many values are not present yet as they are not decoded.
 
-| Offset | Type                                | Name                         | Description                                                                                            |
-| ------ | ----------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------ |
-| 0002   | Byte                                | Type                         | 0: NPC/Player, 1: Monster ?                                                                            |
-| 0003   | Byte                                | Gender                       | 0: Male, 1: Female                                                                                     |
-| 0004   | Byte                                | Race                         | See below                                                                                              |
-| 0005   | Byte                                | Class                        | See below                                                                                              |
-| 0006   | Byte                                | Current ATK                  | Attack                                                                                                 |
-| 0007   | Byte                                | Current PAR                  | Parry                                                                                                  |
-| 0008   | Byte                                | Current SWI                  | Swim                                                                                                   |
-| 0009   | Byte                                | Current LIS                  | Listen                                                                                                 |
-| 000A   | Byte                                | Current F-T                  | Find traps                                                                                             |
-| 000B   | Byte                                | Current D-T                  | Disarm traps                                                                                           |
-| 000C   | Byte                                | Current P-L                  | Pick locks                                                                                             |
-| 000D   | Byte                                | Current SEA                  | Search                                                                                                 |
-| 000E   | Byte                                | Current RMS                  | Read magic scrolls                                                                                     |
-| 000F   | Byte                                | Current U-M                  | Use magic                                                                                              |
-| 0010   | Byte                                | Max ATK                      | Attack                                                                                                 |
-| 0011   | Byte                                | Max PAR                      | Parry                                                                                                  |
-| 0012   | Byte                                | Max SWI                      | Swim                                                                                                   |
-| 0013   | Byte                                | Max LIS                      | Listen                                                                                                 |
-| 0014   | Byte                                | Max F-T                      | Find traps                                                                                             |
-| 0015   | Byte                                | Max D-T                      | Disarm traps                                                                                           |
-| 0016   | Byte                                | Max P-L                      | Pick locks                                                                                             |
-| 0017   | Byte                                | Max SEA                      | Search                                                                                                 |
-| 0018   | Byte                                | Max RMS                      | Read magic scrolls                                                                                     |
-| 0019   | Byte                                | Max U-M                      | Use magic                                                                                              |
-| 001A   | Byte                                | Magic Schools                | Flags; 2: white, 4: grey: 8: black, 128: special                                                       |
-| 001B   | Byte                                | Level                        |
-| 001C   | Byte                                | Number of used hands?        |
-| 001D   | Byte                                | Number of used fingers?      |
-| 001E   | Byte                                | DEF                          | Base Defense                                                                                           |
-| 001F   | Byte                                | DAM                          | Base Damage                                                                                            |
-| 0022   | Byte[9]                             | Item amounts                 | For equipped items (0 = none)                                                                          |
-| 002B   | Byte[12]                            | Item amounts                 | For inventory items (0 = none)                                                                         |
-| 0037   | Byte                                | Languages                    | See below                                                                                              |
-| 003A   | Byte                                | Physical Ailments            | See below                                                                                              |
-| 003B   | Byte                                | Mental Ailments              | See below                                                                                              |
-| 003D   | Byte                                | Quest Completion Flag        | ID of a flag that toggles which of the two NPC interaction blocks to use, see "NPC Interactions" below |
-| 003E   | Byte                                | Battle GFX                   | Graphics used in Battle (Monsters only? PC Icon may depend on class value)                             |
-| 0040   | Byte                                | M-B-A                        | Magic armor level                                                                                      |
-| 0041   | Byte                                | Morale                       | Monsters flee when that amount in % of same Monster is defeated                                        |
-| 0043   | Byte                                | APR                          | Attacks per Round                                                                                      |
-| 0044   | Byte                                | Monster flags                | 1: Undead, 2: Demon, 4: Ailment immunity                                                               |
-| 0045   | Byte                                | Monster elemental flags      | See below                                                                                              |
-| 0048   | Word                                | Current STR                  | Strength                                                                                               |
-| 004A   | Word                                | Current INT                  | Intelligence                                                                                           |
-| 004C   | Word                                | Current DEX                  | Dexterity                                                                                              |
-| 004E   | Word                                | Current SPE                  | Speed                                                                                                  |
-| 0050   | Word                                | Current CON                  | Constitution                                                                                           |
-| 0052   | Word                                | Current CHA                  | Charisma                                                                                               |
-| 0054   | Word                                | Current LUC                  | Luck                                                                                                   |
-| 0056   | Word                                | Current MAG                  | Magic?                                                                                                 |
-| 0058   | Word                                | Current AGE                  | Age                                                                                                    |
-| 005A   | Word                                | Current unused attribute?    | Always 0?                                                                                              |
-| 005C   | Word                                | Max STR                      | Strength                                                                                               |
-| 005E   | Word                                | Max INT                      | Intelligence                                                                                           |
-| 0060   | Word                                | Max DEX                      | Dexterity                                                                                              |
-| 0062   | Word                                | Max SPE                      | Speed                                                                                                  |
-| 0064   | Word                                | Max CON                      | Constitution                                                                                           |
-| 0066   | Word                                | Max CHA                      | Charisma                                                                                               |
-| 0068   | Word                                | Max LUC                      | Luck                                                                                                   |
-| 006A   | Word                                | Max MAG                      | Magic?                                                                                                 |
-| 006C   | Word                                | Max AGE                      | Character will die at this age (race dependent)                                                        |
-| 006E   | Word                                | Max unused attribute?        | Always 0?                                                                                              |
-| 0071   | Byte                                | Lvl/Att                      | PC gets additional Attack per round every X levels                                                     |
-| 0072   | Word                                | HP/lvl                       | (This is not exact, but modified by some yet unknown factors)                                          |
-| 0074   | Word                                | SP/lvl                       | (This is not exact, but modified by some yet unknown factors)                                          |
-| 0076   | Word                                | SLP/lvl                      | (This is not exact, but modified by some yet unknown factors)                                          |
-| 0078   | Word                                | TP/lvl                       | Training Points per level                                                                              |
-| 0086   | Word                                | Current HP                   |
-| 0088   | Word                                | Max HP                       |
-| 008A   | Word                                | Current SP                   |
-| 008C   | Word                                | Max SP                       |
-| 0090   | Word                                | Current gold                 |
-| 0092   | Word                                | Current food                 |
-| 0094   | Word                                | Defense                      | Seems to be used by players only? Maybe each byte has a meaning like variable and base defense?        |
-| 0096   | Word                                | Damage                       | Seems to be used by players only? Maybe each byte has a meaning like variable and base damage?         |
-| 00CC   | Long                                | Experience Points            |
-| 00D0   | Long                                | Known spells (white)         | See [Spells](Spells.md)                                                                                |
-| 00D4   | Long                                | Known spells (grey)          | See [Spells](Spells.md)                                                                                |
-| 00D8   | Long                                | Known spells (black)         | See [Spells](Spells.md)                                                                                |
-| 00E8   | Long                                | Known spells (special)       | See [Spells](Spells.md)                                                                                |
-| 00EC   | Long                                | Total weight in grams        |
-| 00F0   | Byte[16]                            | Name                         | 15 chars for the name and a terminating 0 (the game allows entering 19 chars but only stores 15)       |
-| 0100   | Byte[25]                            | Monster spell schools        | See below                                                                                              |
-| 0119   | Byte[25]                            | Monster spell ids            | See below                                                                                              |
-| 0132   | Item[9]                             | Equipped items               |
-| 029A   | Item[12]                            | Inventory items              |
-| 047A   | Byte[560]                           | Interactions                 | Up to 20 NPC Interactions (see below)                                                                  |
-| 06AA   | [Pixmap](Pixmaps.md))               | Portrait (optional)          | Portrait [Pixmap](Pixmaps.md) with full header.                                                        |
-| 08D0   | [CompressedText](CompressedText.md) | Dialogue Messages (optional) |
+| Offset | Type                                | Name                                         | Description                                                                                            |
+|--------|-------------------------------------|----------------------------------------------|--------------------------------------------------------------------------------------------------------|
+| 0002   | Byte                                | Type                                         | 0: NPC/Player, 1: Monster ?                                                                            |
+| 0003   | Byte                                | Gender                                       | 0: Male, 1: Female                                                                                     |
+| 0004   | Byte                                | Race                                         | See below                                                                                              |
+| 0005   | Byte                                | Class                                        | See below                                                                                              |
+| 0006   | Byte                                | Current ATK                                  | Attack                                                                                                 |
+| 0007   | Byte                                | Current PAR                                  | Parry                                                                                                  |
+| 0008   | Byte                                | Current SWI                                  | Swim                                                                                                   |
+| 0009   | Byte                                | Current LIS                                  | Listen                                                                                                 |
+| 000A   | Byte                                | Current F-T                                  | Find traps                                                                                             |
+| 000B   | Byte                                | Current D-T                                  | Disarm traps                                                                                           |
+| 000C   | Byte                                | Current P-L                                  | Pick locks                                                                                             |
+| 000D   | Byte                                | Current SEA                                  | Search                                                                                                 |
+| 000E   | Byte                                | Current RMS                                  | Read magic scrolls                                                                                     |
+| 000F   | Byte                                | Current U-M                                  | Use magic                                                                                              |
+| 0010   | Byte                                | Max ATK                                      | Attack                                                                                                 |
+| 0011   | Byte                                | Max PAR                                      | Parry                                                                                                  |
+| 0012   | Byte                                | Max SWI                                      | Swim                                                                                                   |
+| 0013   | Byte                                | Max LIS                                      | Listen                                                                                                 |
+| 0014   | Byte                                | Max F-T                                      | Find traps                                                                                             |
+| 0015   | Byte                                | Max D-T                                      | Disarm traps                                                                                           |
+| 0016   | Byte                                | Max P-L                                      | Pick locks                                                                                             |
+| 0017   | Byte                                | Max SEA                                      | Search                                                                                                 |
+| 0018   | Byte                                | Max RMS                                      | Read magic scrolls                                                                                     |
+| 0019   | Byte                                | Max U-M                                      | Use magic                                                                                              |
+| 001A   | Byte                                | Magic Schools                                | Flags; 2: white, 4: grey: 8: black, 128: special                                                       |
+| 001B   | Byte                                | Level                                        |                                                                                                        |
+| 001C   | Byte                                | Number of used hands?                        |                                                                                                        |
+| 001D   | Byte                                | Number of used fingers?                      |                                                                                                        |
+| 001E   | Byte                                | DEF                                          | Base Defense                                                                                           |
+| 001F   | Byte                                | DAM                                          | Base Damage                                                                                            |
+| 0020   | Byte                                | M-B-W                                        | Magic Weapon Level                                                                                     |
+| 0021   | Byte                                | M-B-A from Equipment                         | Is added to DEF when calculating damage                                                                |
+| 0022   | Byte[9]                             | Item amounts                                 | For equipped items (0 = none)                                                                          |
+| 002B   | Byte[12]                            | Item amounts                                 | For inventory items (0 = none)                                                                         |
+| 0037   | Byte                                | Languages                                    | See below                                                                                              |
+| 0038   | Byte                                | Unknown                                      |                                                                                                        |
+| 0039   | Byte                                | Unknown                                      | Always 0                                                                                               |
+| 003A   | Byte                                | Physical Ailments                            | See below                                                                                              |
+| 003B   | Byte                                | Mental Ailments                              | See below                                                                                              |
+| 003C   | Byte                                | Join party chance                            | Needs Verification                                                                                     |
+| 003D   | Byte                                | Quest Completion Flag                        | ID of a flag that toggles which of the two NPC interaction blocks to use, see "NPC Interactions" below |
+| 003E   | Byte                                | Battle GFX                                   | Graphics used in Battle (Monsters only? PC Icon may depend on class value)                             |
+| 003F   | Byte                                | Casting chance                               | Chance to decide to cast a spell; checked after choosing the spell                                     |
+| 0040   | Byte                                | M-B-A                                        | Magic armor level                                                                                      |
+| 0041   | Byte                                | Morale                                       | Monsters flee when that amount in % of same Monster is defeated                                        |
+| 0042   | Byte                                | Monster Rank                                 | Needs verification; Monsters stay behing until all their Minions (lower value) are defeated            |
+| 0043   | Byte                                | APR                                          | Attacks per Round                                                                                      |
+| 0044   | Byte                                | Monster flags                                | 1: Undead, 2: Demon, 4: Ailment immunity                                                               |
+| 0045   | Byte                                | Monster elemental flags                      | See below                                                                                              |
+| 0046   | Byte[2]?                            | Unknown                                      | More flags? Almost all Enemies have 0x07ff                                                             |
+| 0048   | Word                                | Current STR                                  | Strength                                                                                               |
+| 004A   | Word                                | Current INT                                  | Intelligence                                                                                           |
+| 004C   | Word                                | Current DEX                                  | Dexterity                                                                                              |
+| 004E   | Word                                | Current SPE                                  | Speed                                                                                                  |
+| 0050   | Word                                | Current CON                                  | Constitution                                                                                           |
+| 0052   | Word                                | Current CHA                                  | Charisma                                                                                               |
+| 0054   | Word                                | Current LUC                                  | Luck                                                                                                   |
+| 0056   | Word                                | Current MAG                                  | Magic Resistance                                                                                       |
+| 0058   | Word                                | Current AGE                                  | Age                                                                                                    |
+| 005A   | Word                                | Current unused attribute?                    | Always 0                                                                                               |
+| 005C   | Word                                | Max STR                                      | Strength                                                                                               |
+| 005E   | Word                                | Max INT                                      | Intelligence                                                                                           |
+| 0060   | Word                                | Max DEX                                      | Dexterity                                                                                              |
+| 0062   | Word                                | Max SPE                                      | Speed                                                                                                  |
+| 0064   | Word                                | Max CON                                      | Constitution                                                                                           |
+| 0066   | Word                                | Max CHA                                      | Charisma                                                                                               |
+| 0068   | Word                                | Max LUC                                      | Luck                                                                                                   |
+| 006A   | Word                                | Max MAG                                      | Magic Resistance                                                                                       |
+| 006C   | Word                                | Max AGE                                      | Character will die when current age becomes higher than this (race dependent)                          |
+| 006E   | Word                                | Max unused attribute?                        | Always 0                                                                                               |
+| 0070   | Word                                | Lvl/Att                                      | PC gets additional Attack per round every X levels                                                     |
+| 0072   | Word                                | HP/lvl                                       | (This is not exact, but modified by some yet unknown factors)                                          |
+| 0074   | Word                                | SP/lvl                                       | (This is not exact, but modified by some yet unknown factors)                                          |
+| 0076   | Word                                | SLP/lvl                                      | (This is not exact, but modified by some yet unknown factors)                                          |
+| 0078   | Word                                | TP/lvl                                       | Training Points per level                                                                              |
+| 007A   | Byte[12]?                           | Unknown                                      | Always 0                                                                                               |
+| 0086   | Word                                | Current HP                                   |                                                                                                        |
+| 0088   | Word                                | Max HP                                       |                                                                                                        |
+| 008A   | Word                                | Current SP                                   |                                                                                                        |
+| 008C   | Word                                | Max SP                                       |                                                                                                        |
+| 008E   | Word                                | Current SLP                                  |                                                                                                        |
+| 0090   | Word                                | Current gold                                 |                                                                                                        |
+| 0092   | Word                                | Current food                                 |                                                                                                        |
+| 0094   | Word                                | Defense from Equipment                       |                                                                                                        |
+| 0096   | Word                                | Damage from Equipment                        |                                                                                                        |
+| 0098   | Word                                | HP bonus from equipment                      |                                                                                                        |
+| 009A   | Word                                | SP bonus from equipment                      |                                                                                                        |
+| 009C   | Word                                | STR bonus from equipment                     |                                                                                                        |
+| 009E   | Word                                | INT bonus from equipment                     |                                                                                                        |
+| 00A0   | Word                                | DEX bonus from equipment                     |                                                                                                        |
+| 00A0   | Word                                | SPE bonus from equipment                     |                                                                                                        |
+| 00A4   | Word                                | CON bonus from equipment                     |                                                                                                        |
+| 00A6   | Word                                | CHA bonus from equipment                     |                                                                                                        |
+| 00A8   | Word                                | LUC bonus from equipment                     |                                                                                                        |
+| 00AA   | Word                                | MAG bonus from equipment                     |                                                                                                        |
+| 00AC   | Byte[4]                             | Unknown                                      | Always 0                                                                                               |
+| 00B0   | Word                                | ATK bonus from equipment                     |                                                                                                        |
+| 00B2   | Word                                | PAR bonus from equipment                     |                                                                                                        |
+| 00B4   | Word                                | SWI bonus from equipment                     |                                                                                                        |
+| 00B6   | Word                                | LIS bonus from equipment                     |                                                                                                        |
+| 00B8   | Word                                | F-T bonus from equipment                     |                                                                                                        |
+| 00BA   | Word                                | D-T bonus from equipment                     |                                                                                                        |
+| 00BC   | Word                                | P-L bonus from equipment                     |                                                                                                        |
+| 00BE   | Word                                | SEA bonus from equipment                     |                                                                                                        |
+| 00C0   | Word                                | RMS bonus from equipment                     |                                                                                                        |
+| 00C2   | Word                                | U-M bonus from equipment                     |                                                                                                        |
+| 00C4   | Word                                | Join time?                                   | Looks like it could be the game time when the character joined the party                               |
+| 00C6   | Word                                | Experience points for defeating this Monster |                                                                                                        |
+| 00C8   | Word                                | Unknown                                      | seems related to Monster spell points                                                                  |
+| 00CA   | Word                                | Year of Birth                                | 876 - Age; messed up by buggy age changes                                                              | 
+| 00CC   | Long                                | Experience Points                            |                                                                                                        |
+| 00D0   | Long                                | Known spells (white)                         | See [Spells](Spells.md)                                                                                |
+| 00D4   | Long                                | Known spells (grey)                          | See [Spells](Spells.md)                                                                                |
+| 00D8   | Long                                | Known spells (black)                         | See [Spells](Spells.md)                                                                                |
+| 00DC   | Long[3]                             | Known spells (unused)                        |                                                                                                        |
+| 00E8   | Long                                | Known spells (special)                       | See [Spells](Spells.md)                                                                                |
+| 00EC   | Long                                | Total weight in grams                        |                                                                                                        |
+| 00F0   | Byte[16]                            | Name                                         | 15 chars for the name and a terminating 0 (the game allows entering 19 chars but only stores 15)       |
+| 0100   | Byte[25]                            | Monster spell schools                        | See below                                                                                              |
+| 0119   | Byte[25]                            | Monster spell ids                            | See below                                                                                              |
+| 0132   | Item[9]                             | Equipped items                               |                                                                                                        |
+| 029A   | Item[12]                            | Inventory items                              |                                                                                                        |
+| 047A   | Byte[560]                           | Interactions                                 | Up to 20 NPC Interactions (see below)                                                                  |
+| 06AA   | [Pixmap](Pixmaps.md))               | Portrait (optional)                          | Portrait [Pixmap](Pixmaps.md) with full header.                                                        |
+| 08D0   | [CompressedText](CompressedText.md) | Dialogue Messages (optional)                 |                                                                                                        |
 
 **Notes**
 
@@ -188,10 +224,22 @@ Vulnerable means double damage
 
 The “learned spells” flags are only used by Characters. For monsters it works like this:
 
-- There are 25 bytes with spell school values, follwed by 25 bytes with spell ids.
-- A monster can cast a spell if school[i] is set to a spell school and id[i] is set to the corresponding spell id in this school.
-- Example: school[0] = 7, id[0] = 2 means that monster can cast poison., school[1] = 3, id[1] = 20 means it can cast Whirlwind.
-- A monster can have the same spell in multiple slots, probably increasing the chance of casting it (needs confirmation).
+* There are 25 bytes with spell school values, followed by 25 bytes with spell ids.
+* A monster can cast a spell if school[i] is set to a spell school and id[i] is set to the corresponding spell id in this school.
+* Example: school[0] = 7, id[0] = 2 means that monster can cast poison., school[1] = 3, id[1] = 20 means it can cast Whirlwind.
+* A monster can have the same spell in multiple slots, increasing the chance of casting it.
+
+The decision whether to cast a spell works like this:
+```
+let index = rand_int() % 25
+let spell = get_spell(mon.school[index], mon.id[index])
+if mon.iritated() == false && spell != null && spell.cost <= mon.sp && rand_int() % 100 < mon.casting_chance 
+    cast_spell(spell)
+else
+    other_action() // attack | move | parry | run away
+```
+
+Casting chance only affects the decision and does not replace the Use-Magic check.
 
 For values see [Spells](Spells.md)
 
@@ -239,7 +287,7 @@ where:
 **Notes**
 
 - _Give_, _Pay_, and _Feed_ will implicitly remove the item / gp / food that is offered to the NPC.
-- _Join_ will implicitly add the NPC to the party (if possible, otherwise the interaction presumably does not trigger (?)).
+- _Join_ will implicitly add the NPC to the party (if possible, otherwise the interaction is not available).
 
 ### Reactions
 

--- a/FileSpecs/Spells.md
+++ b/FileSpecs/Spells.md
@@ -122,3 +122,39 @@ Spell names are in german (should better be translated by someone with the engli
 | 18 | `40000`  | Schloss Öffnen |
 | 19 | `80000`  | Adlerruf       |
 | 20 | `100000` | Musik          |
+
+## In-Memory-Data
+| Offset | Type | Name |
+|-------:|-----:|-----:|
+| 0 | byte | Element \| Flags \| Location |
+| 1 | byte | SP Cost |
+| 2 | byte | Effect Mod? Not clear how it works. |
+| 3 | byte | Target |
+
+Element | Flags | Location
+
+| Hex | Bit | Name |
+|----:|----:|-----:|
+| 1 |  | Overworld Map |
+| 2 |  | 2d or 3d? |
+| 4 |  | 2d or 3d? |
+| 8 |  | Camp |
+| 10 |  | Combat |
+| 20 |  | IsElemental |
+| 30 | 001x xxxx | Fire |
+| 70 | 011x xxxx | Water |
+| b0 | 101x xxxx | Earth |
+| f0 | 111x xxxx | Wind |
+
+Target
+
+| Bit | Name |
+|----:|-----:|
+| 1 | One Character |
+| 2 | All Characters |
+| 4 | One Enemy |
+| 8 | Group of Enemies |
+| 10 | All Enemies |
+| 20 | Inventory |
+| 40 | Party (Buf) |
+| 80 | Environment |

--- a/FileSpecs/Spells.md
+++ b/FileSpecs/Spells.md
@@ -3,12 +3,12 @@ The id is used for Monsters and the bit value for PCs.
 Spell names are in german (should better be translated by someone with the english version of Amberstar installed).
 
 ## Spell schools
-| Id | Bit | Name    |
-|---:|----:|---------|
-| 1  | `2` | white   |
-| 2  | `4` | grey    |
-| 3  | `8` | black   |
-| 7  | `80`| special |
+| Id |  Bit | Name    |
+|---:|-----:|---------|
+|  1 |  `2` | white   |
+|  2 |  `4` | grey    |
+|  3 |  `8` | black   |
+|  7 | `80` | special |
 
 
 ## White magic
@@ -124,37 +124,37 @@ Spell names are in german (should better be translated by someone with the engli
 | 20 | `100000` | Musik          |
 
 ## In-Memory-Data
-| Offset | Type | Name |
-|-------:|-----:|-----:|
-| 0 | byte | Element \| Flags \| Location |
-| 1 | byte | SP Cost |
-| 2 | byte | Effect Mod? Not clear how it works. |
-| 3 | byte | Target |
+| Offset | Type |                                Name |
+|-------:|-----:|------------------------------------:|
+|      0 | byte |        Element \| Flags \| Location |
+|      1 | byte |                             SP Cost |
+|      2 | byte | Effect Mod? Not clear how it works. |
+|      3 | byte |                              Target |
 
 Element | Flags | Location
 
-| Hex | Bit | Name |
-|----:|----:|-----:|
-| 1 |  | Overworld Map |
-| 2 |  | 2d or 3d? |
-| 4 |  | 2d or 3d? |
-| 8 |  | Camp |
-| 10 |  | Combat |
-| 20 |  | IsElemental |
-| 30 | 001x xxxx | Fire |
-| 70 | 011x xxxx | Water |
-| b0 | 101x xxxx | Earth |
-| f0 | 111x xxxx | Wind |
+| Hex |       Bit |          Name |
+|----:|----------:|--------------:|
+|   1 |           | Overworld Map |
+|   2 |           |     2d or 3d? |
+|   4 |           |     2d or 3d? |
+|   8 |           |          Camp |
+|  10 |           |        Combat |
+|  20 |           |   IsElemental |
+|  30 | 001x xxxx |          Fire |
+|  70 | 011x xxxx |         Water |
+|  b0 | 101x xxxx |         Earth |
+|  f0 | 111x xxxx |          Wind |
 
 Target
 
-| Bit | Name |
-|----:|-----:|
-| 1 | One Character |
-| 2 | All Characters |
-| 4 | One Enemy |
-| 8 | Group of Enemies |
-| 10 | All Enemies |
-| 20 | Inventory |
-| 40 | Party (Buf) |
-| 80 | Environment |
+| Bit |             Name |
+|----:|-----------------:|
+|   1 |    One Character |
+|   2 |   All Characters |
+|   4 |        One Enemy |
+|   8 | Group of Enemies |
+|  10 |      All Enemies |
+|  20 |        Inventory |
+|  40 |      Party (Buf) |
+|  80 |      Environment |


### PR DESCRIPTION
Over the months I did some re-engineering now and then. This MR contains some additional info on `Chardata.amb` and spells.
I wish there was some special diff/merge option to make merging properly formated tables nicer :/

Furthermore I found out some stuff about several game mechanics.  There is also some strange stuff and open questions. Since I'm not sure where to put it best yet, I'll just add it all it to this text for now ;p


## Unclear values in CharData.amb
Note: By Animals, I mean Spike, Shir'kar and Cyriis. Not rats or anything else you have to fight.

#### 0x0038
Maybe old Race value?
* All enemies except Mountain Orc & Skelleton: 8
* Animals: 6
* Olfin & Crag (gnomes): 3
* Bothor & Dönner (dwarves): 2
* Samrais (elf): 1
* All others: 0

#### 0x003c 
Probably chance to join party.
* Trasric (who sometimes refuses to join at first try): 75, Sheba: 95
* Other recruitable characters: 100
* All others: 0

#### 0x0042
Stay behind minions value?
Seems weird for Gwendolyn, but fits perfectly otherwise.

#### 0x0046
More flags? (comes after other monster flags)
* Animals: 2
* All enemies except in final fight: 7
* All others: 0 or 1

#### 0x0047
Flags?
* All enemies except "S-Magier St.12" (DE) have 0xff here. Many others, too.
* Animals: 0x01
* Other values in hex: 13, 23, 31, cb, d3, f1

#### 0x005a, 0x006e, 0x007a, 0x00a
Always 0, so unused Attribute makes sense.

#### 0x00c4* (word); possibly time at which character joined the party
At start it's 0 everywhere. But later has some value for every character that is or was in the party (except for the starting character). Values might correspond to game time when joining the party.

#### 0x00c8 (word)
Found on Monsters that can cast spells and seems to be roughly related to their spell points. The Water Demon has 49 here (and 50 SP). Hailstorm costs 50, so it would not be able to cast that spell if this value would be used instead.

#### 0x00ca (word); Year of birth
This value is always starting at 876 - Age. But it's modification is buggy: artificial aging increases it, instead of decreasing. Youth potions do not affect it.

## Mechanics / Checks

### The Simple ones
* Magic damage / healing is just a random int within the range described in the manual
* Search, Find/Disarm Trap & Spell learning are simple checks vs `rand_int() % 100`
* Fleeing works as in Ambermoon (Dex+Luc vs 150; checked code for evading battle, changed luck in battle - result fits)
* Poison: 1 - 5 damage every full hour
* Disease: -1 to random Attribute when day ends (0:00). No decrease if attribute == 1. Does not try to decrease the unused attribute.
* Age: +1 when sleeping (not when day ends). Birth year is also increased by 1.
* Youth potion: Decrease age by 1-10. If age < 15, age = 15.
* Weapon balm: Increase damage of weapon by 1-4 (to a maximum of 127). There is a bug here: to reflect the changes in the character data, `char_dam_base` is increased by that value instead of `char.dam_equip`. However, this makes no difference in the game.

### Lockpicking
Locks can jam!
```
let lockpick_chance = char.lockpick + char.lockpick_equip
if lockpick_chance >= 100
    open_lock()
else
    lockpick_chance -= lock_data.difficulty
    if rand_int() % 100 < lockpick_chance
        open_lock()
    else
        spring_trap_if_dex_check_fails()
        lock_data.difficulty += 10
        if lock_data.difficulty >= 100
            lock_data.difficulty = 99
```
The difficulty increase is remembered in saved games.

### Attack
At the beginning of each round, an attack modifier `mod_a` is computed for each actor:
```
let mod_a = 100
if diseased
    mod_a /= 2
if irritated
    mod_a *= 75
    mod_a /= 100
if blind
    mod_a /= 4
```

When attacking:
```
let att = char.att + char.att_equipment
att += buf_attack() // can be 0, 5, 10 or 15 depending on active spells
// no idea why, but att is rounded down to an even number, e.g 55 becomes 54, 54 stays
att /= 2
att += att
// apply modification from ailments
att *= mod_a
att *= 100

if rand_int() % 100 < att
    hit()
```

Damage:
```
let dam = attacker.dam_base + attacker.dam_equipment
dam += (attacker.strength / 25)
let rs = defender.armor_base + defender.armor_equipment 
rs += defender.mba // yes, magic armor value is simply added to armor
damage = max (0, (rand_int() % dam) - (rand_int() % rs))
```
Not seen in the code: characters' M-B-W must be >= monsters M-B-A. But this is ignored if the attacker is a monster.

### Level Up
```
char.apr = char.lvl_per_apr / (char.lvl -1)
char.hp_max += char.hp_per_lvl + (char.con + char.con_equip) / 10
if char.magic_schools += 0
    let m_bonus = (char.int + char.int_equip) / 20
    char.sp_max += char.sp_per_lvl + m_bonus
    char.slp += char.slp_per_lvl + m_bonus
```

### Madness
The madness code is buggy!
What basically happens is this:
```
let rand = random_int()
let d = rand % 37
if d & 0b00000001 == 0 
    try_attack()
else if char_ref.is_in_back_row() && d & 0b00000100 == 0
    flee
else // try move 
    m = rand % 5
    let field = char_ref.choose_move_field(m)
    if field != null
        move_to(field)
    else
        parry
        
fn try_attack()
    if char_ref.base_damage + char_ref.equip_damage > 0
       let weapon = char_ref.weapon
       if weapon == null || weapon.is_ranged()
            parry
       else
            target = char_ref.choose_target()
            if target != null
                parry
            else
                attack(target)
                
fn Character.choose_target()
    // choose a random (?) target that the character can reach
    
fn Character.choose_move_field(m)
    // probably returns the field in the direction determined
    // by m if it's free. I didn't check this, but m is 0-4
    // which makes sense, as there are 5 possible directions.
```

Seems fine... so what's the problem?

1. `char_ref` *should* clearly be the mad character that does the action -- but instead it's the first character in the party (in my tests - not ruling out that it might be another one in different circumstances). This explains why mad characters sometimes move multiple fields or attack enemies outside their range.
2. `choose_target()` itself is buggy, too: when I made the first character mad, everything seemed fine... until I moved the 3rd character (who, btw. was equiped with a ranged weapon) next to a monster and the 1st did attack it. `char_ref` was definitively the first character. At this point I decided to stop investigating further.
3. In my tests (maybe ~50 rounds), mad characters never attacked their allies. But I'm pretty sure that *should* happen.
4. If a mad character flees, the code will still be executed every round for as long as `char_ref` is in combat.

## Unsolved mysteries
Besides the unknown values, there are 2 more things that I'm really curious about:

### Gwendolyn
She has various values, that are otherwise only found on monsters. This makes me wonder if there is some chain of events that will make her fight the party.

I tried the following
1. show, but not give, her the rose
2. give it to Olfin instead
3. talk to Gwendolyn again

That triggered nothing. Maybe that will make her join the dark side later?
Did anyone play the game through to the end after giving the rose to Olfin?

Maybe something like that was originally planned, but than not implemented after all.


### Magic Armor
In Ambermoon characters can become immune to physical damage from monsters by increasing their M-B-A value. If it's higher than the monsters M-B-W, the monster will be unable to do damage to the character by non-magical means.

In Amberstar the M-B-A value exists as well, but for characters it's just a hidden bonus to armor class, while working the same as in Ambermoon if attacking monsters.

This might have been intended just like this -- the M-B-W values of monsters suggest this. Or it might have been one of these possibilities:

1. They planned for it to make characters immune in Amberstar, but decided against it late in the process. 
2. In Ambermoon, it should have worked just like in Amberstar, but somehow it didn't... and as time (and money) was running out, they decided to adjust the M-B-W values as a workaround.
